### PR TITLE
Fix displaying email templates translations in Admin Panel

### DIFF
--- a/src/Entity/EmailTemplate.php
+++ b/src/Entity/EmailTemplate.php
@@ -87,7 +87,7 @@ class EmailTemplate implements EmailTemplateInterface
     protected function getBlockTranslation(): EmailTemplateTranslationInterface
     {
         /** @var EmailTemplateTranslationInterface $translation */
-        $translation = $this->createTranslation();
+        $translation = $this->getTranslation();
 
         return $translation;
     }


### PR DESCRIPTION
While refactoring the code by accident `getTranslation` has been replaced by `createTranslation`. This PR fixes it.